### PR TITLE
Change fluid amount to work with fabric fluid system

### DIFF
--- a/src/main/resources/data/createdieselgenerators/recipes/basin_fermenting/dough.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/basin_fermenting/dough.json
@@ -6,7 +6,7 @@
     },
     {
       "fluid": "minecraft:water",
-      "amount": 100
+      "amount": 8100
     }
   ],
   "processingTime": 200,

--- a/src/main/resources/data/createdieselgenerators/recipes/basin_fermenting/fermentable.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/basin_fermenting/fermentable.json
@@ -12,7 +12,7 @@
   "results": [
     {
       "fluid": "createdieselgenerators:ethanol",
-      "amount": 200
+      "amount": 16200
     }
   ]
 }

--- a/src/main/resources/data/createdieselgenerators/recipes/basin_fermenting/fermented_spider_eye.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/basin_fermenting/fermented_spider_eye.json
@@ -9,7 +9,7 @@
     },
     {
       "fluid": "minecraft:water",
-      "amount": 100
+      "amount": 8100
     }
   ],
   "processingTime": 200,
@@ -19,7 +19,7 @@
     },
     {
       "fluid": "createdieselgenerators:ethanol",
-      "amount": 100
+      "amount": 8100
     }
   ]
 }

--- a/src/main/resources/data/createdieselgenerators/recipes/basin_fermenting/golden_apple.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/basin_fermenting/golden_apple.json
@@ -24,7 +24,7 @@
       "nbt": {
         "Potion": "minecraft:mundane"
       },
-      "amount": 100
+      "amount": 8100
     }
   ],
   "processingTime": 400,
@@ -37,7 +37,7 @@
       "nbt": {
         "Potion": "minecraft:thick"
       },
-      "amount": 100
+      "amount": 8100
     }
   ]
 }

--- a/src/main/resources/data/createdieselgenerators/recipes/basin_fermenting/golden_carrot.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/basin_fermenting/golden_carrot.json
@@ -24,7 +24,7 @@
       "nbt": {
         "Potion": "minecraft:mundane"
       },
-      "amount": 100
+      "amount": 8100
     }
   ],
   "processingTime": 400,
@@ -37,7 +37,7 @@
       "nbt": {
         "Potion": "minecraft:thick"
       },
-      "amount": 100
+      "amount": 8100
     }
   ]
 }

--- a/src/main/resources/data/createdieselgenerators/recipes/basin_fermenting/magma_cream.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/basin_fermenting/magma_cream.json
@@ -6,7 +6,7 @@
     },
     {
       "fluid": "minecraft:lava",
-      "amount": 100
+      "amount": 8100
     }
   ],
   "processingTime": 200,

--- a/src/main/resources/data/createdieselgenerators/recipes/compacting/plant_oil.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/compacting/plant_oil.json
@@ -8,7 +8,7 @@
   "results": [
     {
       "fluid": "createdieselgenerators:plant_oil",
-      "amount": 100
+      "amount": 8100
     }
   ]
 }

--- a/src/main/resources/data/createdieselgenerators/recipes/distillation/crude_oil.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/distillation/crude_oil.json
@@ -3,7 +3,7 @@
   "ingredients": [
     {
       "fluidTag": "c:crude_oil",
-      "amount": 100
+      "amount": 8100
     }
   ],
   "heatRequirement": "heated",
@@ -11,11 +11,11 @@
   "results": [
     {
       "fluid": "createdieselgenerators:diesel",
-      "amount": 50
+      "amount": 4050
     },
     {
       "fluid": "createdieselgenerators:gasoline",
-      "amount": 50
+      "amount": 4050
     }
   ]
 }

--- a/src/main/resources/data/createdieselgenerators/recipes/mixing/asphalt_block.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/mixing/asphalt_block.json
@@ -11,7 +11,7 @@
     },
     {
       "fluidTag": "c:crude_oil",
-      "amount": 100
+      "amount": 8100
     }
   ],
   "heatRequirement": "heated",

--- a/src/main/resources/data/createdieselgenerators/recipes/mixing/biodiesel.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/mixing/biodiesel.json
@@ -3,17 +3,17 @@
   "ingredients": [
     {
       "fluidTag": "c:plantoil",
-      "amount": 100
+      "amount": 8100
     },
     {
       "fluidTag": "c:ethanol",
-      "amount": 100
+      "amount": 8100
     }
   ],
   "results": [
     {
       "fluid": "createdieselgenerators:biodiesel",
-      "amount": 200
+      "amount": 16200
     }
   ]
 }


### PR DESCRIPTION
Change amount of fluids. With the forge values the recipes had sometimes weird results. For example distilling always produced uneven numbers of millibuckets. I have not changed Pumpjack oil output, I don't know where to change it. It has to be multiplied by 81 to be the right amount for fabric.  

One question: Why is there a resources folder inside the resources folder? Removing it does not affect anything.