### PR TITLE
Fix NPE Crash

### DIFF
--- a/src/main/java/com/jesz/createdieselgenerators/Events.java
+++ b/src/main/java/com/jesz/createdieselgenerators/Events.java
@@ -96,7 +96,7 @@ public class Events {
 
                             FluidStack fluid = TransferUtil.getFirstFluid(tank);
 
-                            if(FuelTypeManager.getGeneratedSpeed(fluid.getFluid()) == 0)
+                            if(fluid == null || FuelTypeManager.getGeneratedSpeed(fluid.getFluid()) == 0)
                                 continue;
                             level.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
                             try {


### PR DESCRIPTION
This fixes an issue where a potentially `null` return value would crash the game in case of an explosion.

The crash in question: https://paste.kescher.at/?2e7507922ca49422#ChQmQcBHcdKafHBe3u5mMDKrVgVMnKbwhJ661wpxL11v